### PR TITLE
Use target framework netstandard2.0 and default constant NETSTANDARD2_0

### DIFF
--- a/src/PdfSharp/PdfSharp.csproj
+++ b/src/PdfSharp/PdfSharp.csproj
@@ -2,11 +2,10 @@
 
   <PropertyGroup>
     <Version>3.0.0.0</Version>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
-    <DefineConstants>$(DefineConstants);NETCOREAPP;CORE;CORE_WITH_GDI</DefineConstants>
-    <AssemblyName>PdfSharp.netcoreapp</AssemblyName>
-    <PackageId>PdfSharp.netcoreapp</PackageId>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <DefineConstants>$(DefineConstants);CORE;CORE_WITH_GDI</DefineConstants>
+    <AssemblyName>PdfSharp.netstandard2.0</AssemblyName>
+    <PackageId>PdfSharp.netstandard2.0</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -42,7 +41,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="4.5.0-preview2-26406-04" />
+    <PackageReference Include="System.Drawing.Common" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/PdfSharp/Windows/PagePreview-ag.xaml.cs
+++ b/src/PdfSharp/Windows/PagePreview-ag.xaml.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCOREAPP
+﻿#if !NETSTANDARD2_0
 
 using System;
 using System.Collections.Generic;

--- a/src/PdfSharp/Windows/PagePreview-wpf.xaml.cs
+++ b/src/PdfSharp/Windows/PagePreview-wpf.xaml.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCOREAPP
+﻿#if !NETSTANDARD2_0
 
 using System;
 using System.Collections.Generic;

--- a/src/PdfSharp/Windows/PagePreviewDesignTimeData.cs
+++ b/src/PdfSharp/Windows/PagePreviewDesignTimeData.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCOREAPP
+﻿#if !NETSTANDARD2_0
 
 using System;
 using System.Net;

--- a/src/PdfSharp/Windows/VisualPresenter.cs
+++ b/src/PdfSharp/Windows/VisualPresenter.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCOREAPP
+﻿#if !NETSTANDARD2_0
 
 
 using System;

--- a/src/PdfSharp/Windows/enums/RenderMode.cs
+++ b/src/PdfSharp/Windows/enums/RenderMode.cs
@@ -27,7 +27,7 @@
 // DEALINGS IN THE SOFTWARE.
 #endregion
 
-#if !NETCOREAPP
+#if !NETSTANDARD2_0
 
 namespace PdfSharp.Windows
 {

--- a/src/PdfSharp/Windows/enums/Zoom.cs
+++ b/src/PdfSharp/Windows/enums/Zoom.cs
@@ -27,7 +27,7 @@
 // DEALINGS IN THE SOFTWARE.
 #endregion
 
-#if !NETCOREAPP
+#if !NETSTANDARD2_0
 
 namespace PdfSharp.Windows
 {


### PR DESCRIPTION
System.Drawing.Common 4.5.0 has been released.

Also PdfSharp is a class library, so it should depend on netstandard2.0 instead of netcoreapp2.0.

And with netstandard2.0 there comes a default constant NETSTANDARD2_0, so use that.